### PR TITLE
Handle empty profiling choices

### DIFF
--- a/src/components/CookieBanner/CookieSettings.jsx
+++ b/src/components/CookieBanner/CookieSettings.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import CookieGroupSettings from './CookieGroupSettings';
+import React from "react";
+import CookieGroupSettings from "./CookieGroupSettings";
 
 const CookieSettings = ({ preferences, setPreferences, panelConfig }) => {
   return (
@@ -16,16 +16,18 @@ const CookieSettings = ({ preferences, setPreferences, panelConfig }) => {
       </div>
 
       {/******** PROFILING ********/}
-      <div className="settings-column profiling">
-        <CookieGroupSettings
-          id="profiling"
-          groupConfig={panelConfig.profiling}
-          disabled={false}
-          preferences={preferences}
-          setPreferences={setPreferences}
-          autofocus={true}
-        />
-      </div>
+      {panelConfig.profiling?.choices?.length > 0 && (
+        <div className="settings-column profiling">
+          <CookieGroupSettings
+            id="profiling"
+            groupConfig={panelConfig.profiling}
+            disabled={false}
+            preferences={preferences}
+            setPreferences={setPreferences}
+            autofocus={true}
+          />
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
This is the result when ``panelConfig.profiling.choices`` is an empty array:

<img width="735" alt="Schermata 2022-07-28 alle 17 59 25" src="https://user-images.githubusercontent.com/14176608/181584029-1c78631c-b809-4b62-aa4c-0ed55945718a.png">
