### PR TITLE
fix: Us#75601 prevent video when cookie not accepted

### DIFF
--- a/src/customizations/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/components/manage/Blocks/Video/Body.jsx
@@ -69,6 +69,18 @@ const getVideoIDAndPlaceholder = (url) => {
  * @extends Component
  */
 const Body = ({ data, isEditMode }) => {
+
+  const gdprPreferences = useSelector(
+    (state) => {
+      return state.gdprPrivacyConsent ? state.gdprPrivacyConsent?.preferences : [];
+    },
+  ); 
+
+  const embedAllowed =
+    gdprPreferences !== undefined &&
+    (gdprPreferences?.prof_VIMEO === true ||
+      gdprPreferences?.prof_YOUTUBE === true);
+
   let placeholder = data.preview_image
     ? isInternalURL(data.preview_image)
       ? `${flattenToAppURL(data.preview_image)}/@@images/image`
@@ -104,7 +116,7 @@ const Body = ({ data, isEditMode }) => {
           })}
         >
           <ConditionalEmbed url={data.url}>
-            {data.url.match('youtu') ? (
+            {embedAllowed && (data.url.match('youtu') ? (
               <>
                 {data.url.match('list') ? (
                   <Embed
@@ -152,7 +164,7 @@ const Body = ({ data, isEditMode }) => {
                   </>
                 )}
               </>
-            )}
+            ))}
           </ConditionalEmbed>
         </div>
       )}

--- a/src/customizations/components/manage/Blocks/Video/Body.jsx
+++ b/src/customizations/components/manage/Blocks/Video/Body.jsx
@@ -129,7 +129,7 @@ const Body = ({ data, isEditMode }) => {
               </>
             ) : (
               <>
-                {data.url.match('vimeo') ? (
+                {embedAllowed && (data.url.match('vimeo') ? (
                   <Embed id={videoID} source="vimeo" {...embedSettings} />
                 ) : (
                   <>
@@ -162,7 +162,7 @@ const Body = ({ data, isEditMode }) => {
                       <div className="invalidVideoFormat" />
                     )}
                   </>
-                )}
+                ))}
               </>
             ))}
           </ConditionalEmbed>


### PR DESCRIPTION
[Us#75601](https://redturtle.tpondemand.com/RestUI/Board.aspx#page=bug/75601)

Prevent to fetch video when cookie are not accepted, passed to ConditionalEmbed only when cookie are accepted.