### PR TITLE
fix: ConditionalEmbed hydration mismatch on cookie-gated embeds

### DIFF
--- a/src/components/ConditionalEmbed/ConditionalEmbed.jsx
+++ b/src/components/ConditionalEmbed/ConditionalEmbed.jsx
@@ -47,8 +47,13 @@ const ConditionalEmbed = ({ code, url, children }) => {
   );
 
   const [urlReferenceConfig, setUrlReferenceConfig] = useState(null);
+  const [mounted, setMounted] = useState(false);
 
   const isEmptyObj = (o) => Object.keys(o ?? {}).length === 0;
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     if (profilingConfig && !urlReferenceConfig) {
@@ -86,8 +91,14 @@ const ConditionalEmbed = ({ code, url, children }) => {
     embedDisabled = true;
   }
 
-  if (cookieConsentEnabled && __SERVER__) {
-    return <div></div>; // it has to return something (and not a simple React.fragment) because client-rendering will replace it with next block confusing rendering
+  if (cookieConsentEnabled && (__SERVER__ || !mounted)) {
+    // The server always renders an empty placeholder (it can't safely know
+    // the user's cookie consent), so the client's first hydration render has
+    // to match that exactly. Only compute the real conditional content once
+    // mounted (post-hydration), or React complains about a markup mismatch.
+    // It has to return something (and not a simple React.fragment) because
+    // client-rendering will replace it with next block confusing rendering.
+    return <div></div>;
   }
   if (
     cookieConsentEnabled &&


### PR DESCRIPTION
ConditionalEmbed rendered a bare <div></div> on the server (cookieConsentEnabled && __SERVER__), since the server can't safely know the user's actual cookie consent. But on the client's first hydration render, __SERVER__ is false and gdprPreferences/urlReferenceConfig haven't been populated yet (they only load via useEffect/Redux after mount), so it fell into the "diffView" branch and rendered a <strong>Embed: </strong> placeholder instead. React then complains the server HTML doesn't contain a matching `<strong>`, and hydration fails for every page with a cookie-gated embed (e.g. a Video block).

Add a `mounted` flag that starts false and flips to true in a mount effect, and defer to the same empty-div placeholder on the client until mounted, so the first client render always matches what the server actually sent. The real conditional content (accept-cookies message, diffView placeholder, or the embed itself) now only renders after hydration completes.